### PR TITLE
Added multi line support similar to how it works in emacs

### DIFF
--- a/autoload/org_eval.vim
+++ b/autoload/org_eval.vim
@@ -168,17 +168,16 @@ function! org_eval#OrgEval() abort " {{{
   if !empty(cmd)
     call s:writeSrcBlock(block['lines'])
     let result = split(system(cmd . ' ' . g:org_eval_tmp_file) , '\n')
-    if len(result) > 0 " if result
-      call append(block['end'], 'RESULT: ' . result[0])
-      let lnum = block['end']+1
-	  " append multi line output
-      for line in result[1:] " every line after the first
-        call append(lnum, '      : ' . line)
-        let lnum = lnum + 1
-        endfor
-    else " if no result
-      call append(block['end'], 'RESULT: ')
+    if len(result) <= 0 " if no result
+      let result = ['']
     endif
+    call append(block['end'], 'RESULT: ' . result[0])
+    let lnum = block['end']+1
+    " append multi line output
+    for line in result[1:] " every line after the first
+      call append(lnum, '      : ' . line)
+      let lnum = lnum + 1
+    endfor
     else
       if empty(lang)
         echo 'Language not specified'

--- a/autoload/org_eval.vim
+++ b/autoload/org_eval.vim
@@ -163,18 +163,22 @@ function! org_eval#OrgEval() abort " {{{
   let block = s:getSrcBlock()
 
   if !empty(block)
-    let lang  = s:getLang(block['start'])
-    let cmd   = get(g:org_eval_run_cmd, lang, "")
-    if !empty(cmd)
-      call s:writeSrcBlock(block['lines'])
-      let result = split(system(cmd . ' ' . g:org_eval_tmp_file) , '\n')
+  let lang  = s:getLang(block['start'])
+  let cmd   = get(g:org_eval_run_cmd, lang, "")
+  if !empty(cmd)
+    call s:writeSrcBlock(block['lines'])
+    let result = split(system(cmd . ' ' . g:org_eval_tmp_file) , '\n')
+    if len(result) > 0 " if result
       call append(block['end'], 'RESULT: ' . result[0])
-	  let lnum = block['end']+1
+      let lnum = block['end']+1
+	  " append multi line output
       for line in result[1:] " every line after the first
         call append(lnum, '      : ' . line)
         let lnum = lnum + 1
-      endfor
-
+        endfor
+    else " if no result
+      call append(block['end'], 'RESULT: ')
+    endif
     else
       if empty(lang)
         echo 'Language not specified'

--- a/autoload/org_eval.vim
+++ b/autoload/org_eval.vim
@@ -167,7 +167,7 @@ function! org_eval#OrgEval() abort " {{{
   let cmd   = get(g:org_eval_run_cmd, lang, "")
   if !empty(cmd)
     call s:writeSrcBlock(block['lines'])
-    let result = split(system(cmd . ' ' . g:org_eval_tmp_file) , '\n')
+    let result = systemlist(cmd . ' ' . g:org_eval_tmp_file)
     if len(result) <= 0 " if no result
       let result = ['']
     endif

--- a/autoload/org_eval.vim
+++ b/autoload/org_eval.vim
@@ -167,8 +167,14 @@ function! org_eval#OrgEval() abort " {{{
     let cmd   = get(g:org_eval_run_cmd, lang, "")
     if !empty(cmd)
       call s:writeSrcBlock(block['lines'])
-      let result = s:cleanStr(system(cmd . ' ' . g:org_eval_tmp_file))
-      call append(block['end'], 'RESULT: ' . result)
+      let result = split(system(cmd . ' ' . g:org_eval_tmp_file) , '\n')
+      call append(block['end'], 'RESULT: ' . result[0])
+	  let lnum = block['end']+1
+      for line in result[1:] " every line after the first
+        call append(lnum, '      : ' . line)
+        let lnum = lnum + 1
+      endfor
+
     else
       if empty(lang)
         echo 'Language not specified'


### PR DESCRIPTION
Originally OrgEval.vim would simply join the lines but now multiple lines are kept separate. Could always add an option for those that prefer it to only be one line.